### PR TITLE
Clarifying helptext for ConcurrentAppend, Append, and Create.

### DIFF
--- a/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
@@ -43,7 +43,7 @@
           "application/octet-stream"
         ],
         "operationId": "FileSystem_ConcurrentAppend",
-        "description": "Appends to the specified file. This method supports multiple concurrent appends to the file. NOTE: ConcurrentAppend and normal (serial) Append CANNOT be used interchangeably; once a file has been appended to using either of these append options, it can only be appended to using that append option. ConcurrentAppend DOES NOT guarantee order and can result in duplicated data landing in the target file.",
+        "description": "Appends to the specified file, optionally first creating the file if it does not yet exist. This method supports multiple concurrent appends to the file. NOTE: The target must not contain data added by Create or normal (serial) Append. ConcurrentAppend and Append cannot be used interchangeably; once a target file has been modified using either of these append options, the other append option cannot be used on the target file. ConcurrentAppend does not guarantee order and can result in duplicated data landing in the target file.",
         "parameters": [
           {
             "name": "filePath",
@@ -577,7 +577,7 @@
           "application/octet-stream"
         ],
         "operationId": "FileSystem_Append",
-        "description": "Appends to the specified file. This method does not support multiple concurrent appends to the file. NOTE: Concurrent append and normal (serial) append CANNOT be used interchangeably. Once a file has been appended to using either append option, it can only be appended to using that append option. Use the ConcurrentAppend option if you would like support for concurrent appends.",
+        "description": "Appends to the specified file. NOTE: The target must not contain data added by ConcurrentAppend. ConcurrentAppend and Append cannot be used interchangeably; once a target file has been modified using either of these append options, the other append option cannot be used on the target file.",
         "parameters": [
           {
             "name": "directFilePath",
@@ -666,7 +666,7 @@
           "application/octet-stream"
         ],
         "operationId": "FileSystem_Create",
-        "description": "Creates a file with optionally specified content.",
+        "description": "Creates a file with optionally specified content. NOTE: If content is provided, the resulting file cannot be modified using ConcurrentAppend.",
         "parameters": [
           {
             "name": "directFilePath",


### PR DESCRIPTION
Clarifying helptext for ConcurrentAppend, Append, and Create.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.