### PR TITLE
Updating parameter description

### DIFF
--- a/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
@@ -378,7 +378,7 @@
               "type": "object",
               "format": "file"
             },
-            "description": "A list of Data Lake Store paths (starting with '/') of the source files. Must be in the format: sources=<comma separated list>"
+            "description": "A list of Data Lake Store paths (starting with '/') of the source files. Must be in the format: sources={comma-separated path list}, such as: sources=/file/path/1.txt,/file/path/2.txt,/file/path/lastfile.csv"
           },
           {
             "name": "op",

--- a/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
@@ -378,7 +378,7 @@
               "type": "object",
               "format": "file"
             },
-            "description": "A list of Data Lake Store paths (starting with '/') of the source files. Must be in the format: sources={comma-separated path list}, such as: sources=/file/path/1.txt,/file/path/2.txt,/file/path/lastfile.csv"
+            "description": "A list of Data Lake Store paths (starting with '/') of the source files. Must be a comma-separated path list in the format: sources=/file/path/1.txt,/file/path/2.txt,/file/path/lastfile.csv"
           },
           {
             "name": "op",


### PR DESCRIPTION
Updating parameter description to remove < and > symbols, for consumers who may be removing perceived HTML tags.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.